### PR TITLE
Keep aspect ratio when resizing the window

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # steel
 
-Hopefully this will become a 2D game framework, but for now it's just a hobby project I'm using to explore CMake, SDL2 and Catch2.
+2d game framework **pet project** using C++17, SDL2, Entt and Catch2. Definitely not ready for serious
+usage.
 
 
 # Inspiration

--- a/steel/include/components.hpp
+++ b/steel/include/components.hpp
@@ -104,10 +104,10 @@ struct LineComponent
 
 struct RectangleComponent
 {
-    float x;
-    float y;
-    float width;
-    float height;
+    int x;
+    int y;
+    int width;
+    int height;
     Color color; // defaults to green
     bool is_filled; //if `true` renders a filled rectangle
     bool is_visible; // defaults to `true`

--- a/steel/include/game.hpp
+++ b/steel/include/game.hpp
@@ -59,9 +59,6 @@ private:
 
     SdlUniquePtr<SDL_Window> window;
     SharedPtr<SDL_Renderer> renderer;
-    // Used for pixel-perfect rendering, so small resolution games can be stretched to the window.
-    // The whole scene is draw into this texture.
-    SdlUniquePtr<SDL_Texture> scene_texture;
 
     Assets assets;
 

--- a/steel/include/game.hpp
+++ b/steel/include/game.hpp
@@ -39,6 +39,18 @@ public:
     Assets& GetAssets() { return assets; }
 
 private:
+    void InitializeRenderer();
+    void InitializeEntities();
+    void ProcessInput();
+    void UpdateLogic(DeltaTime dt);
+    void Render();
+
+    void UpdateTransforms();
+    void RenderTexture(const TextureComponent& texture_component, const TransformComponent& transform_component);
+    void RenderRectangle(const RectangleComponent& rect_component, const TransformComponent &transform_component);
+    void RenderLine(const LineComponent& line_component, const TransformComponent &transform_component);
+
+private:
     entt::registry world;
     entt::entity scene_root;
 
@@ -51,19 +63,6 @@ private:
     Assets assets;
 
     GameUpdateFunction update_game_func;
-
-    void InitializeRenderer();
-    void InitializeEntities();
-    void ProcessInput();
-    void UpdateLogic(DeltaTime dt);
-    void Render();
-
-    void UpdateTransforms();
-    void RenderTexture(
-        const TextureComponent& texture_component, const TransformComponent& transform_component
-    );
-    void RenderRectangle(RectangleComponent& rect_component, const TransformComponent &transform_component);
-    void RenderLine(LineComponent& line_component, const TransformComponent &transform_component);
 };
 
 }

--- a/steel/include/game.hpp
+++ b/steel/include/game.hpp
@@ -59,6 +59,9 @@ private:
 
     SdlUniquePtr<SDL_Window> window;
     SharedPtr<SDL_Renderer> renderer;
+    // Used for pixel-perfect rendering, so small resolution games can be stretched to the window.
+    // The whole scene is draw into this texture.
+    SdlUniquePtr<SDL_Texture> scene_texture;
 
     Assets assets;
 

--- a/steel/include/steel_math.hpp
+++ b/steel/include/steel_math.hpp
@@ -79,5 +79,7 @@ inline float WrapAngle(float angle)
 // Determines if value is powered by two.
 inline bool IsPowerOfTwo(int value) { return (value > 0) && ((value & (value - 1)) == 0); }
 
+inline bool IsAlmostEqual( float a, float b, float precision = 0.0001f ) { return abs( a - b ) <= precision; }
+
 } //Math
 } //Steel

--- a/steel/src/game.cpp
+++ b/steel/src/game.cpp
@@ -1,6 +1,3 @@
-#include <queue>
-#include <unordered_map>
-
 #include "game.hpp"
 #include "game_info.hpp"
 #include "components.hpp"
@@ -18,6 +15,7 @@ Game::Game(const GameInfo* game_info)
     game_info(game_info),
     window(nullptr),
     renderer(nullptr),
+    scene_texture(nullptr),
     update_game_func( []( Steel::DeltaTime ) {} )
 {}
 
@@ -32,6 +30,9 @@ void Game::Init(){
 
 void Game::InitializeRenderer()
 {
+    STEEL_CORE_ASSERT(
+        game_info->rendering_mode == RenderingMode::PixelPerfect, "Only 'PixelPerfect' rendering is supported for now"
+    );
     if (SDL_Init(SDL_INIT_EVERYTHING) != 0)
     {
         STEEL_CORE_ASSERT(false, "Error initializing SDL.");
@@ -64,10 +65,9 @@ void Game::InitializeRenderer()
         SDL_Quit();
         return;
     }
-    renderer = SdlMakeSharedPtr(
-        //TODO: add vsync member to GameInfo. Rename GameInfo to GameSettings
-        SDL_CreateRenderer(window.get(), -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC)
-    );
+    renderer = SdlMakeSharedPtr( SDL_CreateRenderer(
+        window.get(), -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_TARGETTEXTURE
+    ));
     if (!renderer)
     {
         STEEL_CORE_ASSERT(false, "Error creating SDL renderer.");
@@ -272,8 +272,18 @@ void Game::UpdateTransforms()
 void Game::Render()
 {
     const Color& bg_color = game_info->bg_color;
-    SDL_SetRenderDrawColor(renderer.get(), bg_color.R(), bg_color.G(), bg_color.B(), bg_color.A());
-    SDL_RenderClear(renderer.get()); //clear back buffer
+    SDL_Renderer* sdl_renderer = renderer.get();
+    SDL_SetRenderDrawColor(sdl_renderer, bg_color.R(), bg_color.G(), bg_color.B(), bg_color.A());
+    SDL_RenderClear( sdl_renderer ); //clear back buffer
+
+    scene_texture = SdlMakeUniquePtr( SDL_CreateTexture(
+        sdl_renderer,
+        SDL_PIXELFORMAT_RGBA8888,
+        SDL_TEXTUREACCESS_TARGET,
+        game_info->window_width,
+        game_info->window_height
+    ));
+    SDL_SetRenderTarget( sdl_renderer, scene_texture.get()); // render entities into scene_texture
 
     ComponentUtils::ForEachInHierarchy( world, scene_root, [&]( entt::entity entity )
     {
@@ -290,7 +300,18 @@ void Game::Render()
             RenderLine(world.get<LineComponent>(entity), world.get<TransformComponent>(entity));
         }
     });
-    SDL_RenderPresent(renderer.get()); //swap front and back buffers
+    SDL_SetRenderTarget( sdl_renderer, nullptr); // render scene_texture into window
+    SDL_RenderSetLogicalSize( sdl_renderer, game_info->window_width, game_info->window_height ); // keep game aspect ratio
+    SDL_RenderCopyEx(
+        sdl_renderer,
+        scene_texture.get(),
+        nullptr,
+        nullptr,
+        0,
+        nullptr,
+        SDL_RendererFlip::SDL_FLIP_NONE
+    );
+    SDL_RenderPresent( sdl_renderer ); //swap front and back buffers
 }
 
 void Game::RenderTexture(
@@ -301,45 +322,20 @@ void Game::RenderTexture(
     {
         return;
     }
-    switch (game_info->rendering_mode)
-    {
-        case RenderingMode::PixelPerfect:
-        {
-            SDL_Rect dest;
-            dest.w = Math::Round(transform_component.scale.x * (float) texture_component.width);
-            dest.h = Math::Round(transform_component.scale.y * (float) texture_component.height);
-            dest.x = Math::Round(transform_component.world_position.x);
-            dest.y = Math::Round(transform_component.world_position.y);
-            SDL_RenderCopyEx(
-                renderer.get(),
-                sdl_texture,
-                nullptr,
-                &dest,
-                transform_component.rotation,
-                nullptr,
-                SDL_RendererFlip::SDL_FLIP_NONE
-            );
-            break;
-        }
-        case RenderingMode::Default:
-        {
-            SDL_FRect dest;
-            dest.w = transform_component.scale.x * (float) texture_component.width;
-            dest.h = transform_component.scale.y * (float) texture_component.height;
-            dest.x = transform_component.world_position.x;
-            dest.y = transform_component.world_position.y;
-            SDL_RenderCopyExF(
-                renderer.get(),
-                sdl_texture,
-                nullptr,
-                &dest,
-                transform_component.rotation,
-                nullptr,
-                SDL_RendererFlip::SDL_FLIP_NONE
-            );
-            break;
-        }
-    }
+    SDL_Rect dest;
+    dest.w = Math::Round(transform_component.scale.x * (float) texture_component.width);
+    dest.h = Math::Round(transform_component.scale.y * (float) texture_component.height);
+    dest.x = Math::Round(transform_component.world_position.x);
+    dest.y = Math::Round(transform_component.world_position.y);
+    SDL_RenderCopyEx(
+        renderer.get(),
+        sdl_texture,
+        nullptr,
+        &dest,
+        transform_component.rotation,
+        nullptr,
+        SDL_RendererFlip::SDL_FLIP_NONE
+    );
 }
 
 void Game::RenderRectangle(const RectangleComponent& rect_component, const TransformComponent &transform_component)
@@ -355,23 +351,19 @@ void Game::RenderRectangle(const RectangleComponent& rect_component, const Trans
         rect_component.color.B(),
         rect_component.color.A()
     );
-
-    SDL_FRect rect{
-        rect_component.x + transform_component.world_position.x,
-        rect_component.y + transform_component.world_position.y,
-        rect_component.width * transform_component.scale.x,
-        rect_component.height * transform_component.scale.y
+    SDL_Rect rect{
+        rect_component.x + (int) transform_component.world_position.x,
+        rect_component.y + (int) transform_component.world_position.y,
+        (int) (rect_component.width * transform_component.scale.x),
+        (int) (rect_component.height * transform_component.scale.y)
     };
     if (rect_component.is_filled)
     {
-        //TODO: SDL_RenderFillRectsF apparently supports batching, so that is something to consider here
-        SDL_RenderFillRectF(renderer.get(), &rect);
+        SDL_RenderFillRect(renderer.get(), &rect);
     }
     else
     {
-        //SDL_RenderDrawRectsF just does N calls to SDL_RenderDrawRectF, so no need to worry into changing to
-        // SDL_RenderDrawRectsF here
-        SDL_RenderDrawRectF(renderer.get(), &rect);
+        SDL_RenderDrawRect(renderer.get(), &rect);
     }
 }
 
@@ -388,8 +380,7 @@ void Game::RenderLine(const LineComponent& line_component, const TransformCompon
         line_component.color.B(),
         line_component.color.A()
     );
-    //TODO: SDL_RenderDrawLinesF apparently supports batching, so that's something to consider here
-    SDL_RenderDrawLineF(
+    SDL_RenderDrawLine(
         renderer.get(),
         transform_component.world_position.x + line_component.p1.x, //TODO apply scale and rotation
         transform_component.world_position.y + line_component.p1.y,

--- a/steel/src/game.cpp
+++ b/steel/src/game.cpp
@@ -290,7 +290,7 @@ void Game::Render()
             RenderLine(world.get<LineComponent>(entity), world.get<TransformComponent>(entity));
         }
     });
-    SDL_RenderPresent(renderer.get()); //swap front and back buffers:
+    SDL_RenderPresent(renderer.get()); //swap front and back buffers
 }
 
 void Game::RenderTexture(
@@ -301,39 +301,48 @@ void Game::RenderTexture(
     {
         return;
     }
-    SDL_FRect dest;
     switch (game_info->rendering_mode)
     {
         case RenderingMode::PixelPerfect:
         {
+            SDL_Rect dest;
             dest.w = Math::Round(transform_component.scale.x * (float) texture_component.width);
             dest.h = Math::Round(transform_component.scale.y * (float) texture_component.height);
             dest.x = Math::Round(transform_component.world_position.x);
             dest.y = Math::Round(transform_component.world_position.y);
+            SDL_RenderCopyEx(
+                renderer.get(),
+                sdl_texture,
+                nullptr,
+                &dest,
+                transform_component.rotation,
+                nullptr,
+                SDL_RendererFlip::SDL_FLIP_NONE
+            );
             break;
         }
         case RenderingMode::Default:
         {
+            SDL_FRect dest;
             dest.w = transform_component.scale.x * (float) texture_component.width;
             dest.h = transform_component.scale.y * (float) texture_component.height;
             dest.x = transform_component.world_position.x;
             dest.y = transform_component.world_position.y;
+            SDL_RenderCopyExF(
+                renderer.get(),
+                sdl_texture,
+                nullptr,
+                &dest,
+                transform_component.rotation,
+                nullptr,
+                SDL_RendererFlip::SDL_FLIP_NONE
+            );
             break;
         }
     }
-    //TODO decide between SDL_RenderCopy and SDL_RenderCopyF (consider pixel perfect movement)
-    SDL_RenderCopyExF(
-            renderer.get(),
-            sdl_texture,
-            nullptr,
-            &dest,
-            transform_component.rotation,
-            nullptr,
-            SDL_RendererFlip::SDL_FLIP_NONE
-    );
 }
 
-void Game::RenderRectangle(RectangleComponent& rect_component, const TransformComponent &transform_component)
+void Game::RenderRectangle(const RectangleComponent& rect_component, const TransformComponent &transform_component)
 {
     if (!rect_component.is_visible)
     {
@@ -366,7 +375,7 @@ void Game::RenderRectangle(RectangleComponent& rect_component, const TransformCo
     }
 }
 
-void Game::RenderLine(LineComponent& line_component, const TransformComponent &transform_component)
+void Game::RenderLine(const LineComponent& line_component, const TransformComponent &transform_component)
 {
     if (!line_component.is_visible)
     {

--- a/steel_tests/test_game.cpp
+++ b/steel_tests/test_game.cpp
@@ -23,6 +23,9 @@ TEST_CASE( "test_game", "[test_game]" )
 {
     GameInfo game_info{};
     game_info.window_title = "Potato Game!";
+    game_info.window_width = 960;
+    game_info.window_height = 540;
+    game_info.is_window_resizable = true;
     Game game( &game_info );
     game.Init();
 


### PR DESCRIPTION
There's 2 ways of achieving this: 

1. rendering the scene into a texture and then resizing the texture to fit the window
2. use `SDL_RenderSetLogicalSize` and let SDL2 decide how to handle the resize

I chose 2, but kept the commit of version 1 for future reference (with a `render_to_scene_texture_keep_aspect_ratio` tag).

solves #14 